### PR TITLE
Added compatibility for macOS

### DIFF
--- a/src/little.c
+++ b/src/little.c
@@ -6,6 +6,11 @@
 #include <stdio.h>
 #include <setjmp.h>
 
+#if defined(__APPLE__)
+  #define sprintf_s snprintf
+  #define strncpy_s(dst, dstsz, src, count) strncpy(dst, src, count)
+#endif
+
 static lt_Value LT_NULL = LT_VALUE_NULL;
 
 typedef struct {

--- a/src/little.h
+++ b/src/little.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stddef.h> // size_t
 
 typedef uint64_t lt_Value;
 

--- a/src/little.h
+++ b/src/little.h
@@ -361,7 +361,7 @@ typedef void (*lt_ErrorFn)(struct lt_VM* vm, const char*);
 #define LT_DEDUP_TABLE_SIZE 64
 #endif
 
-typedef struct {
+typedef struct lt_VM {
 	lt_Buffer heap;
 	lt_Buffer keepalive;
 

--- a/src/little_std.c
+++ b/src/little_std.c
@@ -7,6 +7,10 @@
 #include <math.h>
 #include <time.h>
 
+#if defined(__APPLE__)
+  #define sprintf_s snprintf
+#endif
+
 void ltstd_open_all(lt_VM* vm)
 {
 	ltstd_open_io(vm);


### PR DESCRIPTION
- Removed `_s` functions for macOS
- In `little.h` size_t is used in `typedef void* (*lt_AllocFn)(size_t);` but it is never defined